### PR TITLE
Add hostname as prefix when you create the route53

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+hostname

--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,13 @@ endif
 					-var "SERVER_HOSTNAME=$(SERVER_HOSTNAME)" \
 	-target aws_route53_record.domain 
 
-start-client: ## starting up the Kerberos Client
+start-client: get_hostname ## starting up the Kerberos Client
 	@echo "Starting up a new Client added in Kerberos environment"
 	cd kerberos-environment && \
 	cat /dev/null > $(TF_LOG_PATH) && \
-	terraform apply -var-file $(SETTINGS_FILE) -target aws_instance.kerberos-client
+	terraform apply -var-file $(SETTINGS_FILE) \
+					-var "SERVER_HOSTNAME=$(SERVER_HOSTNAME)" \
+					-target aws_instance.kerberos-client
 
 delete-client: ## delete the client
 	@echo "Deleting the Client added in Kerberos environment"
@@ -55,6 +57,6 @@ cleanup: ## deleting existing Kerberos environment
 	cd kerberos-environment && \
 	terraform destroy -var-file $(SETTINGS_FILE)
 
-get_hostname: # return t		
+get_hostname:
 	$(eval SERVER_HOSTNAME:=$(shell echo `iconv -f UTF-16 -t UTF-8 kerberos-server-ami/hostname`))
 	@echo Server hostname: $(SERVER_HOSTNAME)

--- a/Makefile
+++ b/Makefile
@@ -25,15 +25,18 @@ build-server: ## building a new Kerberos AMI
 	packer validate -var-file $(SETTINGS_FILE) template.json && \
 	packer $(BUILD_ARGS) -var-file $(SETTINGS_FILE) template.json
 
-start-server: ## starting up the Kerberos Server
+start-server: get_hostname ## starting up the Kerberos Server
 ifeq ($(AMI_ID), )
-	@echo "Please provide AMI ID:\n\t $$ make start AMI_ID=ami-0ea1f0fbfefbe5956"
+	@echo "Please provide AMI ID:\n\t $$ make start-server AMI_ID=ami-0ea1f0fbfefbe5956"
 	@exit 1
 endif
 	@echo "Creating a new Kerberos Environment"
 	cd kerberos-environment && \
 	cat /dev/null > $(TF_LOG_PATH) && \
-	terraform apply -var-file $(SETTINGS_FILE) -var "SERVER_AMI=$(AMI_ID)" -target aws_route53_record.domain 
+	terraform apply -var-file $(SETTINGS_FILE) \
+					-var "SERVER_AMI=$(AMI_ID)" \
+					-var "SERVER_HOSTNAME=$(SERVER_HOSTNAME)" \
+	-target aws_route53_record.domain 
 
 start-client: ## starting up the Kerberos Client
 	@echo "Starting up a new Client added in Kerberos environment"
@@ -41,7 +44,17 @@ start-client: ## starting up the Kerberos Client
 	cat /dev/null > $(TF_LOG_PATH) && \
 	terraform apply -var-file $(SETTINGS_FILE) -target aws_instance.kerberos-client
 
+delete-client: ## delete the client
+	@echo "Deleting the Client added in Kerberos environment"
+	cd kerberos-environment && \
+	cat /dev/null > $(TF_LOG_PATH) && \
+	terraform destroy -var-file $(SETTINGS_FILE) -target aws_instance.kerberos-client
+
 cleanup: ## deleting existing Kerberos environment
 	@echo "Deleting existing Kerberos Environment"
 	cd kerberos-environment && \
 	terraform destroy -var-file $(SETTINGS_FILE)
+
+get_hostname: # return t		
+	$(eval SERVER_HOSTNAME:=$(shell echo `iconv -f UTF-16 -t UTF-8 kerberos-server-ami/hostname`))
+	@echo Server hostname: $(SERVER_HOSTNAME)

--- a/Makefile
+++ b/Makefile
@@ -60,3 +60,11 @@ cleanup: ## deleting existing Kerberos environment
 get_hostname:
 	$(eval SERVER_HOSTNAME:=$(shell echo `iconv -f UTF-16 -t UTF-8 kerberos-server-ami/hostname`))
 	@echo Server hostname: $(SERVER_HOSTNAME)
+
+config: get_hostname ## generate the krb5.config
+	cd kerberos-environment && \
+	cat /dev/null > $(TF_LOG_PATH) && \
+	terraform apply -var-file $(SETTINGS_FILE) \
+					-var "SERVER_HOSTNAME=$(SERVER_HOSTNAME)" \
+					-target local_file.krb5_config
+

--- a/README.md
+++ b/README.md
@@ -70,8 +70,14 @@ $ make start-client
 | Username      | `KERBEROS_TEST_USERNAME`@`DOMAIN`.`HOSTED_ZONE`  |
 | Password      | `KERBEROS_TEST_PASSWORD` |
 
+#### d) generate kerberos configuration krb5.conf
+> there is [krb5.config](https://docs.alfresco.com/6.1/tasks/kerberos-alfresco-config.html) file that you need to generate in order to use these environment(s). Generate it, running this command:
 
-#### d) cleanup everithing
+```
+$ make config
+```
+
+#### e) cleanup everithing
 > this will delete the kerberos server and windows machine, route53 created. It will NOT delete the AMI
 
 ```

--- a/kerberos-environment/ec2-kerberos-client.tf
+++ b/kerberos-environment/ec2-kerberos-client.tf
@@ -40,3 +40,16 @@ data "template_file" "setup_client" {
   }
 }
 
+data "template_file" "krb5_config" {
+  template = "${file("files/krb5.conf.tmpl")}"
+  vars = {
+    DOMAIN                  = "${var.DOMAIN}"
+    HOSTED_ZONE             = "${var.HOSTED_ZONE}"
+    SERVER_HOSTNAME         = "${var.SERVER_HOSTNAME}"        
+  }
+}
+
+resource "local_file" "krb5_config" {
+    content     = "${data.template_file.krb5_config.rendered}"
+    filename = "../krb5.config"
+}

--- a/kerberos-environment/ec2-kerberos-client.tf
+++ b/kerberos-environment/ec2-kerberos-client.tf
@@ -35,7 +35,8 @@ data "template_file" "setup_client" {
     SERVER_ADMIN_USERNAME   = "${var.SERVER_ADMIN_USERNAME}"
     SERVER_ADMIN_PASSWORD   = "${var.SERVER_ADMIN_PASSWORD}"    
     DOMAIN                  = "${var.DOMAIN}"
-    HOSTED_ZONE             = "${var.HOSTED_ZONE}"    
+    HOSTED_ZONE             = "${var.HOSTED_ZONE}"
+    SERVER_HOSTNAME         = "${var.SERVER_HOSTNAME}"    
   }
 }
 

--- a/kerberos-environment/files/krb5.conf.tmpl
+++ b/kerberos-environment/files/krb5.conf.tmpl
@@ -1,0 +1,14 @@
+[libdefaults]
+default_realm = ${upper(DOMAIN)}.${upper(HOSTED_ZONE)}
+default_tkt_enctypes = rc4-hmac
+default_tgs_enctypes = rc4-hmac
+
+[realms]
+${upper(DOMAIN)}.${upper(HOSTED_ZONE)} = {
+# access via internal IP addreses
+   kdc = ${lower(SERVER_HOSTNAME)}.${lower(DOMAIN)}.${lower(HOSTED_ZONE)}
+}
+
+[domain_realm]
+${lower(SERVER_HOSTNAME)}.${lower(DOMAIN)}.${lower(HOSTED_ZONE)} = ${upper(DOMAIN)}.${upper(HOSTED_ZONE)}
+.${lower(SERVER_HOSTNAME)}.${lower(DOMAIN)}.${lower(HOSTED_ZONE)} = ${upper(DOMAIN)}.${upper(HOSTED_ZONE)}

--- a/kerberos-environment/files/setup-client.ps1
+++ b/kerberos-environment/files/setup-client.ps1
@@ -5,10 +5,10 @@ Write-Host "Sucessfully setup network aaa"
 net user admin ${SERVER_ADMIN_USERNAME} /add /y
 net localgroup administrators kerberosauth /add
 
-$domain = "${SERVER_HOSTNAME}.${DOMAIN}.${HOSTED_ZONE}"
+$domain = "${DOMAIN}.${HOSTED_ZONE}".ToLower()
 # set DNS ip address
 $ping = New-Object System.Net.NetworkInformation.Ping
-$ip = $($ping.Send($domain).Address).IPAddressToString
+$ip = $($ping.Send("${SERVER_HOSTNAME}.${DOMAIN}.${HOSTED_ZONE}").Address).IPAddressToString
 
 netsh dnsclient add dnsserver "Ethernet" $ip 4
 

--- a/kerberos-environment/files/setup-client.ps1
+++ b/kerberos-environment/files/setup-client.ps1
@@ -5,7 +5,7 @@ Write-Host "Sucessfully setup network aaa"
 net user admin ${SERVER_ADMIN_USERNAME} /add /y
 net localgroup administrators kerberosauth /add
 
-$domain = "${DOMAIN}.${HOSTED_ZONE}"
+$domain = "${SERVER_HOSTNAME}.${DOMAIN}.${HOSTED_ZONE}"
 # set DNS ip address
 $ping = New-Object System.Net.NetworkInformation.Ping
 $ip = $($ping.Send($domain).Address).IPAddressToString

--- a/kerberos-environment/providers.tf
+++ b/kerberos-environment/providers.tf
@@ -5,3 +5,7 @@ provider "aws" {
 provider "template" {
   version = "~> 2.1"  
 }
+
+provider "local" {
+  version = "~> 1.4"  
+}

--- a/kerberos-environment/route53.tf
+++ b/kerberos-environment/route53.tf
@@ -4,7 +4,7 @@ data "aws_route53_zone" "hosted" {
 
 resource "aws_route53_record" "domain" {
   zone_id = "${data.aws_route53_zone.hosted.zone_id}"
-  name    = "${var.DOMAIN}.${var.HOSTED_ZONE}"
+  name    = "${var.SERVER_HOSTNAME}.${var.DOMAIN}.${var.HOSTED_ZONE}"
   type    = "A"
   ttl     = "300"
   records = ["${aws_instance.kerberos-server.private_ip}"]

--- a/kerberos-environment/variables.tf
+++ b/kerberos-environment/variables.tf
@@ -6,6 +6,11 @@ variable "REGION" {
   default = "eu-west-1"
 }
 
+variable "SERVER_HOSTNAME" {
+  description = "What is the hostname of the Kerberos Server"  
+  default     = "dynamically-set"
+}
+
 variable "SERVER_AMI" {
   description = "Which Kerberos AMI should we use to create new EC2 Instance"  
   default     = "to-be-provided"

--- a/kerberos-server-ami/template.json
+++ b/kerberos-server-ami/template.json
@@ -50,6 +50,16 @@
             ]
         },
         {
+            "type": "powershell",            
+            "inline": [ "hostname > c:/hostname" ]
+        },
+        {
+            "type": "file",
+            "direction": "download",
+            "source": "c:/hostname",
+            "destination": "./hostname"
+        },
+        {
             "type": "powershell",
             "environment_vars": [
                 "ADMIN={{user `SERVER_ADMIN_USERNAME`}}",                


### PR DESCRIPTION
Fixing #7 
* save the hostname when we create the ami with packer
* add hostname as prefix when you create the route53 address in terraform
* add hostname file to ignore list
* update makefile to include the hostname